### PR TITLE
Selenium 4.x support

### DIFF
--- a/lib/capybara/chromedriver/logger/collector.rb
+++ b/lib/capybara/chromedriver/logger/collector.rb
@@ -53,7 +53,6 @@ module Capybara
           Capybara
             .current_session
             .driver.browser
-            .manage
             .logs
             .get(type)
         end


### PR DESCRIPTION
- https://github.com/dbalatero/capybara-chromedriver-logger/pull/38/commits/10632e6daa92fc849c0f92d0fb981a63e2ef750f